### PR TITLE
Fix - move sql templates into binary build using embed directive

### DIFF
--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"embed"
 	"fmt"
 
 	"github.com/arobson/spry/storage"
@@ -12,6 +13,9 @@ import (
 type QueryData struct {
 	ActorName string
 }
+
+//go:embed sql
+var sqlFiles embed.FS
 
 func queryData(name string) QueryData {
 	return QueryData{ActorName: name}
@@ -25,15 +29,17 @@ func CreatePostgresStorage(connectionURI string) storage.Storage {
 	}
 
 	// load templates
-	templates, err := storage.CreateTemplateFrom(
-		"./sql/insert_command.sql",
-		"./sql/insert_event.sql",
-		"./sql/insert_map.sql",
-		"./sql/insert_snapshot.sql",
-		"./sql/select_events_since.sql",
-		"./sql/select_latest_snapshot.sql",
-		"./sql/select_id_by_map.sql",
+	templates, err := storage.CreateTemplateFromFS(
+		sqlFiles,
+		"sql/insert_command.sql",
+		"sql/insert_event.sql",
+		"sql/insert_map.sql",
+		"sql/insert_snapshot.sql",
+		"sql/select_events_since.sql",
+		"sql/select_latest_snapshot.sql",
+		"sql/select_id_by_map.sql",
 	)
+
 	if err != nil {
 		fmt.Println("failed to read sql templates")
 		panic("oh no")

--- a/storage/template.go
+++ b/storage/template.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"io/fs"
 	"text/template"
 )
 
@@ -30,8 +31,16 @@ func (st StringTemplate) Execute(name string, data any) (string, error) {
 	return buffer.String(), nil
 }
 
-func CreateTemplateFrom(paths ...string) (*StringTemplate, error) {
+func CreateTemplateFromPaths(paths ...string) (*StringTemplate, error) {
 	t, err := template.ParseFiles(paths...)
+	if err != nil {
+		return nil, err
+	}
+	return &StringTemplate{templates: t}, nil
+}
+
+func CreateTemplateFromFS(files fs.FS, paths ...string) (*StringTemplate, error) {
+	t, err := template.ParseFS(files, paths...)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/sql/create_actor_schema.sql
+++ b/tests/sql/create_actor_schema.sql
@@ -1,0 +1,46 @@
+CREATE IF NOT EXISTS TABLE {{.ActorName}}_commands (
+    id              uuid            PRIMARY KEY,
+    actor_id        uuid            NOT NULL,
+    content         jsonb,
+    created_on      timestamp with time zone            DEFAULT now(),
+    vector          varchar(9192),
+    version         bigint          NOT NULL,
+)
+
+CREATE INDEX IF NOT EXISTS {{.ActorName}}_command_actor_idx on {{.ActorName}}_commands(actor_id);
+
+CREATE TABLE IF NOT EXISTS {{.ActorName}}_events (
+    id              uuid            PRIMARY KEY,
+    actor_id        uuid            NOT NULL,
+    content         jsonb,
+    created_on      timestamp with time zone            DEFAULT now(),
+    vector          varchar(9192),
+    version         bigint          NOT NULL,
+);
+
+CREATE INDEX IF NOT EXISTS {{.ActorName}}_event_actor_idx on {{.ActorName}}_events(actor_id);
+
+CREATE TABLE IF NOT EXISTS {{.ActorName}}_id_map (
+    id                      uuid        PRIMARY KEY,
+    identifiers             jsonb       NOT NULL,
+    actor_id                uuid        NOT NULL,
+    starting_on             timestamp with time zone 	DEFAULT now(),
+    UNIQUE(identifiers, actor_id)
+);
+
+CREATE INDEX IF NOT EXISTS {{.ActorName}}_id_map_actor_idx on {{.ActorName}}_id_map(actor_id);
+CREATE INDEX IF NOT EXISTS {{.ActorName}}_id_map_ids_idx on {{.ActorName}}_id_map(identifiers);
+
+CREATE TABLE IF NOT EXISTS {{.ActorName}}_snapshots (
+	id								uuid	        PRIMARY KEY,
+    actor_id                        uuid            NOT NULL,
+	content							jsonb 			NOT NULL,
+	last_command_id					uuid  	        NOT NULL,
+	last_command_handled_on			timestamp with time zone  		NOT NULL,
+	last_event_id					uuid 	        NOT NULL,
+    last_event_applied_on			timestamp with time zone  		NOT NULL,
+	vector							varchar(9192),
+	version							bigint 			NOT NULL,
+);
+
+CREATE INDEX IF NOT EXISTS {{.ActorName}}_snapshot_actor_idx on {{.ActorName}}_snapshots(actor_id);

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -1,19 +1,29 @@
 package tests
 
 import (
+	"embed"
 	"strings"
 	"testing"
 
 	"github.com/arobson/spry/storage"
 )
 
+//go:embed sql
+var sqlFiles embed.FS
+
 func TestCreateTemplate(t *testing.T) {
 	type Data struct {
 		ActorName string
 	}
-	result, err := storage.CreateFromTemplate(
+	templates, err := storage.CreateTemplateFromFS(
+		sqlFiles,
+		"sql/create_actor_schema.sql",
+	)
+	if err != nil {
+		t.Error("failed to create templates from embedded FS", err)
+	}
+	result, err := templates.Execute(
 		"create_actor_schema.sql",
-		"../postgres/sql/create_actor_schema.sql",
 		Data{ActorName: strings.ToLower("TesT")},
 	)
 	if err != nil {


### PR DESCRIPTION
Adds new method for getting templates from embedded file systems (Go made this super easy). Added test coverage to ensure this behaves correctly and should allow other projects to reference the package without further issues.