### PR TITLE
Feature: snapshot config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
+  ci-build: # This is the name of the workflow, feel free to change it to better match your workflow.
     # Inside the workflow, you define the jobs you want to run.
     jobs:
       - build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # spry
 
+## `main` build [![CircleCI](https://dl.circleci.com/status-badge/img/gh/arobson/spry/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/arobson/spry/tree/main)
+
 An event sourcing library in Go.
 
-> A simplistic postgres storage and in-memory storage implementation are working.
+> Initial postgres backed and in-memory storage implementation are functional.
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ func (p Player) GetIdentifiers() spry.Identifiers {
 	return spry.Identifiers{"Name": p.Name}
 }
 
+// Actors may optionally implement a method that returns
+// configuration details to the storage engine in spry
+// to control how often and when spry should take a snapshot.
+
+func (p Player) GetConfiguration() spry.ActorMeta {
+	// defaults are shown below
+	return spry.ActorMeta{
+		snapshotFrequency: 			10, // produces snapshots often
+		snapshotDuringRead: 		false, // prevents snapshotting during fetch (read)
+		snapshotDuringWrite: 		true, // take snapshots during command handling (write)
+		snapshotDuringPartition: 	true, // if supported by the storage adpater, 
+										// snapshot even if a partition is detected
+	}
+}
+
 // Commands are Verb-Noun named structures that target a specific
 // Actor using the same function signature that Actors have.
 // The command must carry enough information to correctly
@@ -173,4 +188,49 @@ In contrast, an event sourced approach like this one has has the following advan
 
 ## Concepts
 
+### Availability and Partition Tolerance
+
+spry provides some configuration behaviors for Actors that allow the application to tune behaviors like snapshotting frequency to adapt to specific data access patterns without forcing application authors to delve into implementation details. That said, it's focus is on providing an approach to event sourcing that is very similar to CRDT's in that storage adapters _can_ detect divergent replicas (incompatible snapshots) and repair them automatically when possible. This means that partitions in your system or storage layer don't have to result in offline modes or degraded availability.
+
+### Emphasis on Simplicity
+
+While spry certainly has a few complex routines that are part of its 
+
+### Actors
+
+An actor's role is to provide data and identifiers that uniquely set it apart from every other Actor of the same type. They can include methods that handle a Command or apply an event but this is a stylist choice for the application authors to make.
+
+### Commands
+
+A command is how we define change to an Actor's state. Instead of mutating the Actor state directly, the command should result in one or more events **or** one or more errors. Events define the changes to take place when applied to the model while errors should explain to the application why the Actor's logic refuses to handle the command.
+
+### Events
+
+Events are essentially a mutator attached to data. With ordering guarantees, we can always load events, apply them in order to a baseline (or new instance) and get the same result. This quality is sometimes referred to as, "commutation" because different processes can derive the same state independent of one another given access to the event log.
+
+### Ordering Guarantees
+
+Spry makes use of [RFC 4122 v6](https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-03#section-5.1) which provides coordination-free, k-ordered, UUIDs. These ids are used as ids across all record types. This should ensure that events and snapshots can always sort in the order they were created. 
+
+### Snapshots
+
+Snapshots are a point-in-time capture of an Actor's state. Creating these at regular, configurable intervals prevents spry from having to read _every_ event that has occurred for a particular actor over its entire history.
+
 ## Storage
+
+### Philosophy
+
+When writing a storage adapter for spry, it's important to remember a few guiding principles:
+
+ * Every Actor should receive its own set of tables/buckets/storage
+ * All write operations should append only (`INSERT` never `UPDATE`)
+ * The UUIDs produced by Spry should never be exposed to the application
+ * Spry expects that the Identifiers map will map to a consistent UUID
+
+### CommandStore
+
+### EventStore
+
+### MapStore
+
+### SnapshotStore

--- a/memory/inmemory.go
+++ b/memory/inmemory.go
@@ -84,7 +84,7 @@ type InMemorySnapshotStore struct {
 	Snapshots map[uuid.UUID][]storage.Snapshot
 }
 
-func (store *InMemorySnapshotStore) Add(ctx context.Context, actorType string, snapshot storage.Snapshot) error {
+func (store *InMemorySnapshotStore) Add(ctx context.Context, actorType string, snapshot storage.Snapshot, allowPartition bool) error {
 	if store.Snapshots == nil {
 		store.Snapshots = map[uuid.UUID][]storage.Snapshot{}
 	}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -205,11 +205,11 @@ func TestSnapshotStorage(t *testing.T) {
 	}
 
 	ctx, _ := store.GetContext(context.Background())
-	err := store.AddSnapshot(ctx, "Player", snap1)
+	err := store.AddSnapshot(ctx, "Player", snap1, true)
 	if err != nil {
 		t.Fatal("failed to persist snapshot 1", err)
 	}
-	err = store.AddSnapshot(ctx, "Player", snap2)
+	err = store.AddSnapshot(ctx, "Player", snap2, true)
 	if err != nil {
 		t.Fatal("failed to persist snapshot 2", err)
 	}

--- a/postgres/snapshotstore.go
+++ b/postgres/snapshotstore.go
@@ -15,7 +15,7 @@ type PostgresSnapshotStore struct {
 	Templates storage.StringTemplate
 }
 
-func (store *PostgresSnapshotStore) Add(ctx context.Context, actorName string, snapshot storage.Snapshot) error {
+func (store *PostgresSnapshotStore) Add(ctx context.Context, actorName string, snapshot storage.Snapshot, allowPartition bool) error {
 	query, _ := store.Templates.Execute(
 		"insert_snapshot.sql",
 		queryData(actorName),

--- a/primitives.go
+++ b/primitives.go
@@ -10,6 +10,43 @@ type Actor[T any] interface {
 	GetIdentifiers() Identifiers
 }
 
+type ActorMeta struct {
+	// how many events should occur before the next snapshot
+	SnapshotFrequency int
+	// controls whether snapshots occur during fetch (read)
+	SnapshotDuringRead bool
+	// controls whether snapshots occur during handle (write)
+	SnapshotDuringWrite bool
+	// controls whether snapshots can occur during partitions
+	// requires a storage adapter for a database that can
+	// detect this
+	SnapshotDuringPartition bool
+}
+
+type HasMeta interface {
+	GetActorMeta() ActorMeta
+}
+
+var default_meta = ActorMeta{
+	SnapshotFrequency:       20,
+	SnapshotDuringRead:      false,
+	SnapshotDuringWrite:     true,
+	SnapshotDuringPartition: true,
+}
+
+func getEmpty[T Actor[T]]() T {
+	return *new(T)
+}
+
+func GetActorMeta[T Actor[T]]() ActorMeta {
+	var empty any = getEmpty[T]()
+	hasMeta, ok := empty.(HasMeta)
+	if ok {
+		return hasMeta.GetActorMeta()
+	}
+	return default_meta
+}
+
 type Command interface {
 	GetIdentifiers() Identifiers
 	Handle(any) ([]Event, []error)
@@ -25,19 +62,19 @@ type Repository[T Actor[T]] interface {
 	Handle(command Command) Results[T]
 }
 
-type Results[T Actor[T]] struct {
-	Original T
-	Modified T
-	Events   []Event
-	Errors   []error
-}
-
 func IdMapToString(ids Identifiers) (string, error) {
 	bytes, err := ToJson(ids)
 	if err != nil {
 		return "", err
 	}
 	return string(bytes), nil
+}
+
+type Results[T Actor[T]] struct {
+	Original T
+	Modified T
+	Events   []Event
+	Errors   []error
 }
 
 func ToJson[T any](obj T) ([]byte, error) {

--- a/storage/records.go
+++ b/storage/records.go
@@ -33,6 +33,8 @@ type Snapshot struct {
 	CreatedOn time.Time `json:"createdOn"`
 	// the number of events applied to reach the present state
 	EventsApplied uint64 `json:"eventsApplied"`
+	// the number of events since the last snapshot was created
+	EventSinceSnapshot int
 	// the UUID of the last event played against the instance
 	LastEventId uuid.UUID `json:"lastEventId"`
 	// the UUID of the last command handled
@@ -46,7 +48,7 @@ type Snapshot struct {
 }
 
 func (snapshot Snapshot) IsValid() bool {
-	return snapshot.Id.IsNil()
+	return !snapshot.Id.IsNil()
 }
 
 func NewSnapshot(actor any) (Snapshot, error) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -38,7 +38,7 @@ type MapStore interface {
 }
 
 type SnapshotStore interface {
-	Add(context.Context, string, Snapshot) error
+	Add(context.Context, string, Snapshot, bool) error
 	Fetch(context.Context, string, uuid.UUID) (Snapshot, error)
 }
 
@@ -50,7 +50,7 @@ type Storage interface {
 	AddCommand(context.Context, string, CommandRecord) error
 	AddEvents(context.Context, string, []EventRecord) error
 	AddMap(context.Context, string, spry.Identifiers, uuid.UUID) error
-	AddSnapshot(context.Context, string, Snapshot) error
+	AddSnapshot(context.Context, string, Snapshot, bool) error
 	FetchEventsSince(context.Context, string, uuid.UUID, uuid.UUID) ([]EventRecord, error)
 	FetchId(context.Context, string, spry.Identifiers) (uuid.UUID, error)
 	FetchLatestSnapshot(context.Context, string, uuid.UUID) (Snapshot, error)
@@ -77,8 +77,8 @@ func (storage Stores[Tx]) AddMap(ctx context.Context, actorName string, identifi
 	return storage.Maps.Add(ctx, actorName, identifiers, uid)
 }
 
-func (storage Stores[Tx]) AddSnapshot(ctx context.Context, actorName string, snapshot Snapshot) error {
-	return storage.Snapshots.Add(ctx, actorName, snapshot)
+func (storage Stores[Tx]) AddSnapshot(ctx context.Context, actorName string, snapshot Snapshot, allowPartition bool) error {
+	return storage.Snapshots.Add(ctx, actorName, snapshot, allowPartition)
 }
 
 func (storage Stores[Tx]) FetchEventsSince(ctx context.Context, actorName string, actorId uuid.UUID, eventId uuid.UUID) ([]EventRecord, error) {

--- a/tests/actorMeta_test.go
+++ b/tests/actorMeta_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/arobson/spry"
+)
+
+type Withit struct {
+	Name string
+}
+
+func (w Withit) GetIdentifiers() spry.Identifiers {
+	return spry.Identifiers{"Name": w.Name}
+}
+
+func (w Withit) GetActorMeta() spry.ActorMeta {
+	return spry.ActorMeta{
+		SnapshotFrequency:       100,
+		SnapshotDuringRead:      true,
+		SnapshotDuringWrite:     false,
+		SnapshotDuringPartition: false,
+	}
+}
+
+type Without struct {
+	Name string
+}
+
+func (w Without) GetIdentifiers() spry.Identifiers {
+	return spry.Identifiers{"Name": w.Name}
+}
+
+func TestActorWithConfig(t *testing.T) {
+	meta := spry.GetActorMeta[Withit]()
+	if meta.SnapshotFrequency != 100 ||
+		meta.SnapshotDuringPartition == true ||
+		meta.SnapshotDuringRead == false ||
+		meta.SnapshotDuringWrite == true {
+		t.Error("actor meta for withit did not match expected settings")
+	}
+}
+
+func TestActorWithoutConfig(t *testing.T) {
+	meta := spry.GetActorMeta[Without]()
+	if meta.SnapshotFrequency != 20 ||
+		meta.SnapshotDuringPartition == false ||
+		meta.SnapshotDuringRead == true ||
+		meta.SnapshotDuringWrite == false {
+		t.Error("actor meta for withit did not match expected settings")
+	}
+}


### PR DESCRIPTION
Allow the application to opt-in to providing snapshot configuration per Actor that controls:

 * how many events should occur between snapshots
 * whether snapshots should occur during read operation (fetch calls)
 * whether snapshots should occur during write operations (handle calls)
 * if the storage adapter should persist snapshots during partitions (if detectable)